### PR TITLE
fix(deps): bump requests and urllib3 versions to resolve CVEs

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,2 +1,2 @@
-requests~=2.32.5
-urllib3~=2.6.3
+requests>=2.33.0
+urllib3>=2.7.0


### PR DESCRIPTION
Bumps `requests` and `urllib3` to resolve the following CVEs:

- CVE-2026-44432
- CVE-2026-44431
- CVE-2026-25645